### PR TITLE
[FIX] No se mostraba el numero de fila en algunos casos

### DIFF
--- a/web_list_view_sequence/static/src/xml/sequence.xml
+++ b/web_list_view_sequence/static/src/xml/sequence.xml
@@ -14,14 +14,14 @@
         <t t-jquery="t:first" t-operation="replace">
             <t t-call="ListView.row">
                 <t t-set="record" t-value="records.at(index)"/>
-                <t t-set="sequence" t-value="records.indexOf(record) + 1"/>
+                <t t-if="records" t-set="record.attributes.row_n" t-value="records.indexOf(record) + 1"/>
             </t>
         </t>
     </t>
 
     <t t-extend="ListView.row">
         <t t-jquery=".oe_list_record_selector" t-operation="after">
-            <td><t t-esc="sequence"/></td>
+            <td><t t-esc="record.attributes.row_n"/></td>
         </t>
     </t>
 


### PR DESCRIPTION
### Issue:
> En algunos casos no se estaba mostrando el numero de fila, por ejemplo cuando en el tree se mostraban los datos de un m2m como por ejemplo impuestos.
### Solución
Tras debuggear se ha visto que en estos casos pasaba varias veces por esa parte y en una de ellas no se tenemos el campo records, entonces Al hacer el indexOf daba error y lo dejaba vacío. Como al principio de todo cuando pasa si que tenemos el campo records se ha optado por guardar el calculado del numero de fila en el propio record ya que este si que lo tenemos luego cuando vuelve a entrar.
